### PR TITLE
Fix copy of native binaries in graalvm docker image

### DIFF
--- a/amazonlinux-java-graal-community-lambda-runtime/Dockerfile
+++ b/amazonlinux-java-graal-community-lambda-runtime/Dockerfile
@@ -6,13 +6,19 @@ RUN yum install -y gcc gcc-c++ libc6-dev binutils zlib1g-dev curl bash zlib zlib
 
 # get graal...
 ARG JAVA_VERSION=jdk-21.0.0
+ARG ARCH=aarch64
 ENV LANG=en_US.UTF-8
-ENV GRAAL_FILENAME=graalvm-community-${JAVA_VERSION}_linux-x64_bin.tar.gz
+ENV GRAAL_FILENAME=graalvm-community-${JAVA_VERSION}_linux-${ARCH}_bin.tar.gz
 ENV GRAAL_URL=https://github.com/graalvm/graalvm-ce-builds/releases/download/${JAVA_VERSION}/${GRAAL_FILENAME}
 RUN echo $GRAAL_URL
 RUN curl -4 -L $GRAAL_URL -o /tmp/${GRAAL_FILENAME}
 
-RUN tar -zxvf /tmp/${GRAAL_FILENAME} -C /tmp && mv /tmp/${GRAAL_FILENAME} /usr/lib/graalvm
+# extract file to /tmp directory, then search for single added folder and move that
+# this only works if the tar extracts 1 folder, not more than that
+# this is needed because the graal filename is not the same as the extracted directory
+RUN tar -zxvf /tmp/${GRAAL_FILENAME} -C /tmp && \
+    EXTRACTED_DIR=$(find /tmp -mindepth 1 -maxdepth 1 -type d -cnewer /tmp/${GRAAL_FILENAME}) && \
+        mv "$EXTRACTED_DIR" /usr/lib/graalvm
 RUN rm -rf /tmp/*
 
 # add lambda runtime bootstrap script

--- a/amazonlinux-java-graal-community-lambda-runtime/build-and-push.sh
+++ b/amazonlinux-java-graal-community-lambda-runtime/build-and-push.sh
@@ -4,6 +4,14 @@ export AWS_LINUX_VERSION=2.0.20230912.0
 export JAVA_VERSION=jdk-$1
 
 docker build --build-arg AWS_LINUX_VERSION=$AWS_LINUX_VERSION \
+--build-arg ARCH=aarch64 \
+--build-arg JAVA_VERSION="$JAVA_VERSION" \
+-t http4k/amazonlinux-java-graal-community-lambda-runtime:latest-arm64 \
+-t http4k/amazonlinux-java-graal-community-lambda-runtime:amazonlinux$AWS_LINUX_VERSION-"$JAVA_VERSION"-arm64 .
+
+
+docker build --build-arg AWS_LINUX_VERSION=$AWS_LINUX_VERSION \
+--build-arg ARCH=x64 \
 --build-arg JAVA_VERSION="$JAVA_VERSION" \
 -t http4k/amazonlinux-java-graal-community-lambda-runtime \
 -t http4k/amazonlinux-java-graal-community-lambda-runtime:latest \


### PR DESCRIPTION
The copy of the extracted binary was not working correctly, most likely
due to recent changes to the internal folder inside the tar.gz.

This change updates the dockerfile to search for the extracted
directory, rather than assuming its name. Using the found directory
(there can only be one, or this will break again) it moves the correct
directory to the /usr/lib/graalvm folder

This change also makes the dockerfile multiplatform, and it will now
deploy tags for arm64 as well as x64.
