### PR TITLE
Fix platform for arm64 graal native container

### DIFF
--- a/amazonlinux-java-graal-community-lambda-runtime/build-and-push.sh
+++ b/amazonlinux-java-graal-community-lambda-runtime/build-and-push.sh
@@ -3,7 +3,7 @@ set -eu
 export AWS_LINUX_VERSION=2.0.20230912.0
 export JAVA_VERSION=jdk-$1
 
-docker build --build-arg AWS_LINUX_VERSION=$AWS_LINUX_VERSION \
+docker build --platform linux/arm64 --build-arg AWS_LINUX_VERSION=$AWS_LINUX_VERSION \
 --build-arg ARCH=aarch64 \
 --build-arg JAVA_VERSION="$JAVA_VERSION" \
 -t http4k/amazonlinux-java-graal-community-lambda-runtime:latest-arm64 \


### PR DESCRIPTION
I accidentally missed setting the platform of the 
container when building, and as a result the 
built container throws an error:

```
Status: Downloaded newer image for http4k/amazonlinux-java-graal-community-lambda-runtime:latest-arm64
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
Creating native-image...
./packageZip: /usr/lib/graalvm/bin/native-image: /lib/ld-linux-aarch64.so.1: bad ELF interpreter: No such file or directory
```
